### PR TITLE
Closing InputStream created for URI to free the resource handle.

### DIFF
--- a/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfPackage.java
+++ b/odfdom/src/main/java/org/odftoolkit/odfdom/pkg/OdfPackage.java
@@ -1585,16 +1585,22 @@ public class OdfPackage implements Closeable {
 	 * @throws java.lang.Exception In case the file could not be saved
 	 */
 	public void insert(URI sourceURI, String internalPath, String mediaType) throws Exception {
-		InputStream is = null;
-		if (sourceURI.isAbsolute()) {
-			// if the URI is absolute it can be converted to URL
-			is = sourceURI.toURL().openStream();
-		} else {
-			// otherwise create a file class to open the stream
-			is = new FileInputStream(sourceURI.toString());
-		}
-		insert(is, internalPath, mediaType);
-	}
+        InputStream is = null;
+        try {
+            if (sourceURI.isAbsolute()) {
+                // if the URI is absolute it can be converted to URL
+                is = sourceURI.toURL().openStream();
+            } else {
+                // otherwise create a file class to open the stream
+                is = new FileInputStream(sourceURI.toString());
+            }
+            insert(is, internalPath, mediaType);
+        } finally {
+            if (is != null) {
+                is.close();
+            }
+        }
+    }
 
 	/**
 	 * Inserts InputStream into an OdfPackage. An existing file will be replaced.


### PR DESCRIPTION
Without this modification, any inserted file still got a handle after manipulating a document with the API (only an explicit System.gc() call could free the file). And of course, this could also lead to memory leakage.

Related JIRA: https://issues.apache.org/jira/browse/ODFTOOLKIT-468